### PR TITLE
Adding platform info to enforce linux/amd64

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   orca:
+    platform: linux/amd64
     image: varnish/orca
     ports:
       - "80:80"


### PR DESCRIPTION
Adding platform info to enforce `linux/amd64`. This is especially useful for ARM-based Mac devices.